### PR TITLE
feat: add a button to run contents in browser

### DIFF
--- a/_includes/base.html
+++ b/_includes/base.html
@@ -151,6 +151,8 @@
             {% if page.nblink %}
                <div id="slidelink">
                  <a href="{{site.baseurl}}/{{page.path | remove: ".html" | remove: ".md"}}.ipynb">Notebook download</a>
+                 <br>
+                 <a href="{{site.baseurl}}/jupyter-lite/lab/index.html?path={{page.path | remove: ".html" | remove: ".md"}}.ipynb">Run in browser</a>
                </div>
             {% endif %}
             {% if page.slidelink %}


### PR DESCRIPTION
Related to https://github.com/UCL/rsd-engineeringcourse/issues/250

The button takes students directly to the particular notebook on browser and looks like this -

<img width="1445" alt="image" src="https://github.com/user-attachments/assets/59b638ae-ef29-488a-b343-71d024f0e6e1">

cc: @dpshelio